### PR TITLE
Add discord domain & update validation links to support multiple domains

### DIFF
--- a/validation/info/fields_validators.go
+++ b/validation/info/fields_validators.go
@@ -144,11 +144,24 @@ func ValidateLinks(links []Link) error {
 				strings.Join(supportedLinkNames(), ", "))
 		}
 
-		prefix := allowedLinkKeys[*l.Name]
-		if prefix != "" {
-			if !strings.HasPrefix(*l.URL, prefix) {
-				return fmt.Errorf("invalid value '%s' for %s link url, allowed only with prefix: %s",
-					*l.URL, *l.Name, prefix)
+		prefixes, exists := allowedLinkKeys[*l.Name]
+		if exists && len(prefixes) > 0 {
+			valid := false
+			for _, prefix := range prefixes {
+				if strings.HasPrefix(*l.URL, prefix) {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				// Format the prefixes based on their count
+				var prefixMsg string
+				if len(prefixes) == 1 {
+					prefixMsg = fmt.Sprintf("allowed prefix is: %s", prefixes[0])
+				} else {
+					prefixMsg = fmt.Sprintf("allowed prefixes are: %v", prefixes)
+				}
+				return fmt.Errorf("invalid value '%s' for %s link url, %s", *l.URL, *l.Name, prefixMsg)
 			}
 		}
 

--- a/validation/info/fields_validators_test.go
+++ b/validation/info/fields_validators_test.go
@@ -1,0 +1,92 @@
+package info
+
+import "testing"
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func TestValidateLinks(t *testing.T) {
+	t.Run("No validation for less than 2 links", func(t *testing.T) {
+		links := []Link{
+			{Name: stringPtr("twitter"), URL: stringPtr("https://twitter.com/example")},
+		}
+		err := ValidateLinks(links)
+		if err != nil {
+			t.Errorf("Expected no validation (and thus no error) for fewer than 2 links, got %v", err)
+		}
+	})
+
+	t.Run("Invalid prefix for URL", func(t *testing.T) {
+		links := []Link{
+			{Name: stringPtr("discord"), URL: stringPtr("http://twitter.com/example")},
+			{Name: stringPtr("discord"), URL: stringPtr("http//discord.io/example")},
+		}
+		err := ValidateLinks(links)
+		println(err.Error())
+		if err == nil {
+			t.Errorf("Expected error for invalid URL prefix, got nil")
+		}
+	})
+
+	t.Run("Invalid link name", func(t *testing.T) {
+		links := []Link{
+			{Name: stringPtr("unknownLink"), URL: stringPtr("https://unknown.com")},
+			{Name: stringPtr("twitter"), URL: stringPtr("https://twitter.com/example")},
+		}
+		err := ValidateLinks(links)
+		if err == nil {
+			t.Errorf("Expected error for invalid link name, got nil")
+		}
+	})
+
+	t.Run("URL without https:// prefix", func(t *testing.T) {
+		links := []Link{
+			{Name: stringPtr("twitter"), URL: stringPtr("twitter.com/example")},
+			{Name: stringPtr("twitter"), URL: stringPtr("https://twitter.com/example")},
+		}
+		err := ValidateLinks(links)
+		if err == nil {
+			t.Errorf("Expected error for missing https:// prefix, got nil")
+		}
+	})
+
+	var allowedLinkKeys = map[string][]string{
+		"twitter":       {"https://twitter.com/example"},
+		"medium":        {"https://medium.com/@example"},
+		"telegram":      {"https://t.me/example"},
+		"github":        {"https://github.com/example"},
+		"whitepaper":    {"https://somewebsite.com/whitepaper"},
+		"telegram_news": {"https://t.me/example"},
+		"discord":       {"https://discord.com/example", "https://discord.gg/example"},
+		"reddit":        {"https://reddit.com/example"},
+		"facebook":      {"https://facebook.com/example"},
+		"youtube":       {"https://youtube.com/example"},
+		"coinmarketcap": {"https://coinmarketcap.com/example"},
+		"coingecko":     {"https://coingecko.com/example"},
+		"blog":          {"https://example.com"},
+		"forum":         {"https://example.com"},
+		"docs":          {"https://example.com"},
+		"source_code":   {"https://example.com"},
+	}
+
+	for key, domains := range allowedLinkKeys {
+		for _, domain := range domains {
+			t.Run("Valid link for "+key+" with domain "+domain, func(t *testing.T) {
+				links := []Link{
+					{Name: stringPtr(key), URL: stringPtr(domain)},
+					{Name: stringPtr("twitter"), URL: stringPtr("https://twitter.com/example")}, // adding a second link to meet the 2 links requirement
+				}
+				err := ValidateLinks(links)
+				if err != nil {
+					t.Errorf("Expected no error for valid link key %s with domain %s, got %v", key, domain, err)
+				}
+			})
+		}
+	}
+}
+
+func main() {
+	t := &testing.T{}
+	TestValidateLinks(t)
+}

--- a/validation/info/values.go
+++ b/validation/info/values.go
@@ -28,7 +28,7 @@ var (
 		"telegram":      {"https://t.me/"},
 		"telegram_news": {"https://t.me/"}, // Read-only announcement channel.
 		"medium":        {""},              // URL contains 'medium.com'.
-		"discord":       {"https://discord.com/"},
+		"discord":       {"https://discord.gg/", "https://discord.com/"},
 		"reddit":        {"https://reddit.com/"},
 		"facebook":      {"https://facebook.com/"},
 		"youtube":       {"https://youtube.com/"},

--- a/validation/info/values.go
+++ b/validation/info/values.go
@@ -21,23 +21,23 @@ var (
 
 	allowedStatusValues = []string{"active", "spam", "abandoned"}
 
-	allowedLinkKeys = map[string]string{
-		"github":        "https://github.com/",
-		"whitepaper":    "",
-		"twitter":       "https://twitter.com/",
-		"telegram":      "https://t.me/",
-		"telegram_news": "https://t.me/", // Read-only announcement channel.
-		"medium":        "",              // URL contains 'medium.com'.
-		"discord":       "https://discord.com/",
-		"reddit":        "https://reddit.com/",
-		"facebook":      "https://facebook.com/",
-		"youtube":       "https://youtube.com/",
-		"coinmarketcap": "https://coinmarketcap.com/",
-		"coingecko":     "https://coingecko.com/",
-		"blog":          "", // Blog, other than medium.
-		"forum":         "", // Community site.
-		"docs":          "",
-		"source_code":   "", // Other than github.
+	allowedLinkKeys = map[string][]string{
+		"github":        {"https://github.com/"},
+		"whitepaper":    {""},
+		"twitter":       {"https://twitter.com/"},
+		"telegram":      {"https://t.me/"},
+		"telegram_news": {"https://t.me/"}, // Read-only announcement channel.
+		"medium":        {""},              // URL contains 'medium.com'.
+		"discord":       {"https://discord.com/"},
+		"reddit":        {"https://reddit.com/"},
+		"facebook":      {"https://facebook.com/"},
+		"youtube":       {"https://youtube.com/"},
+		"coinmarketcap": {"https://coinmarketcap.com/"},
+		"coingecko":     {"https://coingecko.com/"},
+		"blog":          {""}, // Blog, other than medium.
+		"forum":         {""}, // Community site.
+		"docs":          {""},
+		"source_code":   {""}, // Other than github.
 	}
 
 	whiteSpaceCharacters = []string{"\n", "  "}
@@ -62,11 +62,8 @@ func explorerURLAlternatives(chain, name string) []string {
 }
 
 func linkNameAllowed(str string) bool {
-	if _, exists := allowedLinkKeys[str]; !exists {
-		return false
-	}
-
-	return true
+	_, exists := allowedLinkKeys[str]
+	return exists
 }
 
 func supportedLinkNames() []string {


### PR DESCRIPTION
The format for Discord invitation links has recently transitioned from discord.com/invite to discord.gg/invite. Due to this change, newly established Discord groups face challenges linking their socials in asset PRs because of domain restrictions. This PR aims to address and resolve that limitation to ensure a smoother experience for asset contributors on [TrustWallet's assets repository](https://github.com/trustwallet/assets).

Changes:

Modified the "discord" key's value structure, transitioning from a single string to a slice of strings to accommodate multiple valid prefixes.
Adjusted the validation logic to correctly handle and validate the list of potential prefixes.
Introduced new tests to ensure the ValidateLinks function remains robust and now encompasses the latest changes.